### PR TITLE
isnan is no longer in the global namespace in C++11

### DIFF
--- a/src/RecoVertex/GaussianSumVertexFit/src/GsfVertexWeightCalculator.cc
+++ b/src/RecoVertex/GaussianSumVertexFit/src/GsfVertexWeightCalculator.cc
@@ -56,7 +56,7 @@ double GsfVertexWeightCalculator::calculate(const  VertexState & oldVertex,
   double weight = pow(2. * M_PI, -0.5 * 5) * sqrt(1./sigmaDet) * exp(-0.5 * chi);
   // edm::LogError("GsfVertexWeightCalculator") << "w=" << weight << " chi=" << chi << " sigmaDet=" << sigmaDet;
 
-  if (::isnan(weight) || sigmaDet<=0.) {
+  if (isnan(weight) || sigmaDet<=0.) {
     edm::LogWarning("GsfVertexWeightCalculator") << "Weight is NaN";
     return 0.;
     // return -1.;

--- a/src/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/src/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -240,7 +240,7 @@ private:
    * Checks whether any of the three coordinates is a Nan
    */
   inline bool hasNan(const GlobalPoint& point) const {
-    return (isnan(point.x())|| isnan(point.y()) || isnan(point.z()));
+    return (std::isnan(point.x())|| std::isnan(point.y()) || std::isnan(point.z()));
   }
 
 


### PR DESCRIPTION
Apparently in version 2.23 of glibc the old Unix98 functions isnan and
isinf were removed in C++11 mode since they would conflict with the
C++11 versions. So now we have to specify the std:: namespace all the
time. 

GsfVertexWeightCalculator.cc has a using namespace anyway so this should work correctly even in VC++ but I'm not sure if SequentialVertexFitter.h will be compatible with VC++ and I cannot test it.
